### PR TITLE
Use cartridge-driver instead of connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@ LICENSE file.
     <s3.version>1.10.20</s3.version>
     <solr.version>5.5.3</solr.version>
     <solr6.version>6.4.1</solr6.version>
-    <tarantool.version>1.6.5</tarantool.version>
+    <tarantool.version>0.9.1</tarantool.version>
     <thrift.version>0.8.0</thrift.version>
     <voldemort.version>0.81</voldemort.version>
     <tablestore.version>4.8.0</tablestore.version>

--- a/tarantool/pom.xml
+++ b/tarantool/pom.xml
@@ -33,8 +33,8 @@ LICENSE file.
 
   <dependencies>
     <dependency>
-      <groupId>org.tarantool</groupId>
-      <artifactId>connector</artifactId>
+      <groupId>io.tarantool</groupId>
+      <artifactId>cartridge-driver</artifactId>
       <version>${tarantool.version}</version>
     </dependency>
     <dependency>

--- a/tarantool/src/main/java/site/ycsb/db/TarantoolClient.java
+++ b/tarantool/src/main/java/site/ycsb/db/TarantoolClient.java
@@ -17,13 +17,25 @@
 package site.ycsb.db;
 
 import site.ycsb.*;
-import org.tarantool.TarantoolConnection16;
-import org.tarantool.TarantoolConnection16Impl;
-import org.tarantool.TarantoolException;
+import site.ycsb.DBException;
+import io.tarantool.*;
+import io.tarantool.driver.api.TarantoolServerAddress;
+import io.tarantool.driver.api.TarantoolClientFactory;
+import io.tarantool.driver.api.tuple.TarantoolTuple;
+import io.tarantool.driver.api.TarantoolResult;
+import io.tarantool.driver.api.conditions.Conditions;
+import io.tarantool.driver.api.space.TarantoolSpaceOperations;
+import io.tarantool.driver.api.tuple.TarantoolTupleFactory;
+import io.tarantool.driver.mappers.DefaultMessagePackMapperFactory;
+import io.tarantool.driver.api.tuple.DefaultTarantoolTupleFactory;
+import io.tarantool.driver.exceptions.TarantoolClientException;
+import io.tarantool.driver.api.connection.TarantoolConnectionSelectionStrategyType;
 
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * YCSB binding for <a href="http://tarantool.org/">Tarantool</a>.
@@ -31,32 +43,80 @@ import java.util.logging.Logger;
 public class TarantoolClient extends DB {
   private static final Logger LOGGER = Logger.getLogger(TarantoolClient.class.getName());
 
-  private static final String HOST_PROPERTY = "tarantool.host";
-  private static final String PORT_PROPERTY = "tarantool.port";
+  private static final String HOSTS_PROPERTY = "tarantool.hosts";
   private static final String SPACE_PROPERTY = "tarantool.space";
-  private static final String DEFAULT_HOST = "localhost";
-  private static final String DEFAULT_PORT = "3301";
+  private static final String SPACE_NAME_PROPERTY = "tarantool.spaceName";
+  private static final String DEFAULT_HOST = "localhost:3301";
   private static final String DEFAULT_SPACE = "1024";
+  private static final String KEY_FIELD_NAME = "ycsb_id";
 
-  private TarantoolConnection16 connection;
+  private static final AtomicInteger INIT_COUNT = new AtomicInteger(0);
+
+  private io.tarantool.driver.api.TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> connection;
+
   private int spaceNo;
+  private String spaceName;
+  private TarantoolSpaceOperations<TarantoolTuple, TarantoolResult<TarantoolTuple>> testSpace;
 
+  private static final DefaultMessagePackMapperFactory MAPPERFACTORY = DefaultMessagePackMapperFactory.getInstance();
+  private static final TarantoolTupleFactory TUPLEFACTORY =
+          new DefaultTarantoolTupleFactory(MAPPERFACTORY.defaultComplexTypesMapper());
+
+  @Override
   public void init() throws DBException {
-    Properties props = getProperties();
+    int idx = INIT_COUNT.incrementAndGet();
+    synchronized (INIT_COUNT) {
 
-    int port = Integer.parseInt(props.getProperty(PORT_PROPERTY, DEFAULT_PORT));
-    String host = props.getProperty(HOST_PROPERTY, DEFAULT_HOST);
-    spaceNo = Integer.parseInt(props.getProperty(SPACE_PROPERTY, DEFAULT_SPACE));
+      Properties props = getProperties();
+      List<TarantoolServerAddress> addrList = new ArrayList<>();
+      String hosts = props.getProperty(HOSTS_PROPERTY, DEFAULT_HOST);
+      String[] hostsArr = hosts.split(",");
 
-    try {
-      this.connection = new TarantoolConnection16Impl(host, port);
-    } catch (Exception exc) {
-      throw new DBException("Can't initialize Tarantool connection", exc);
+      for (String instance: hostsArr) {
+        String[] hostPort = instance.split(":");
+        addrList.add(new TarantoolServerAddress(hostPort[0], Integer.valueOf(hostPort[1])));
+      }
+
+      idx = idx % addrList.size();
+
+      TarantoolServerAddress addr = addrList.get(idx);
+
+      spaceName = props.getProperty(SPACE_NAME_PROPERTY);
+      if (spaceName == null) {
+        spaceNo = Integer.parseInt(props.getProperty(SPACE_PROPERTY, DEFAULT_SPACE));
+      }
+
+      this.connection = TarantoolClientFactory.createClient()
+            .withAddress(addr.getHost(), addr.getPort())
+            .withConnections(100)
+            .withConnectTimeout(100)
+            .withReadTimeout(100)
+            .withProxyMethodMapping()
+            .withCredentials("guest", "")
+            .withConnectionSelectionStrategy(TarantoolConnectionSelectionStrategyType.PARALLEL_ROUND_ROBIN)
+            .build();
+
+      try {
+        if (spaceName != null) {
+          testSpace = this.connection.space(spaceName);
+        } else {
+          testSpace = this.connection.space(spaceNo);
+        }
+      } catch (TarantoolClientException exc) {
+        throw new DBException("Can't initialize Tarantool connection", exc);
+      } catch (Exception exc) {
+        throw new DBException("Can't initialize Tarantool connection", exc);
+      }
     }
   }
 
+  @Override
   public void cleanup() throws DBException {
-    this.connection.close();
+    try {
+      this.connection.close();
+    } catch(Exception ex) {
+      throw new DBException();
+    }
   }
 
   @Override
@@ -64,14 +124,16 @@ public class TarantoolClient extends DB {
     return replace(key, values, "Can't insert element");
   }
 
-  private HashMap<String, ByteIterator> tupleConvertFilter(List<String> input, Set<String> fields) {
+  private HashMap<String, ByteIterator> tupleConvertFilter(TarantoolTuple input, Set<String> fields) {
+
     HashMap<String, ByteIterator> result = new HashMap<>();
     if (input == null) {
       return result;
     }
-    for (int i = 1; i < input.toArray().length; i += 2) {
-      if (fields == null || fields.contains(input.get(i))) {
-        result.put(input.get(i), new StringByteIterator(input.get(i + 1)));
+    for (int i = 1; i < input.size(); i=+2) {
+      if (fields == null || fields.contains(input.getString(i))) {
+
+        result.put(input.getString(i), new StringByteIterator(input.getString(i + 1)));
       }
     }
     return result;
@@ -80,13 +142,18 @@ public class TarantoolClient extends DB {
   @Override
   public Status read(String table, String key, Set<String> fields, Map<String, ByteIterator> result) {
     try {
-      List<String> response = this.connection.select(this.spaceNo, 0, Arrays.asList(key), 0, 1, 0);
-      result = tupleConvertFilter(response, fields);
+      TarantoolResult<TarantoolTuple> selectResult = testSpace.select(Conditions.equals(KEY_FIELD_NAME, key)).join();
+
+      HashMap<String, ByteIterator> temp = tupleConvertFilter(selectResult.get(0), fields);
+      if (!temp.isEmpty()) {
+        result.putAll(temp);
+      }
+
       return Status.OK;
-    } catch (TarantoolException exc) {
-      LOGGER.log(Level.SEVERE, "Can't select element", exc);
+    } catch (TarantoolClientException ex) {
+      LOGGER.log(Level.SEVERE, "Can't select element", ex);
       return Status.ERROR;
-    } catch (NullPointerException exc) {
+    } catch (Exception exc) {
       return Status.ERROR;
     }
   }
@@ -95,17 +162,22 @@ public class TarantoolClient extends DB {
   public Status scan(String table, String startkey,
                      int recordcount, Set<String> fields,
                      Vector<HashMap<String, ByteIterator>> result) {
-    List<List<String>> response;
+
+    TarantoolResult<TarantoolTuple> selectResult;
+
     try {
-      response = this.connection.select(this.spaceNo, 0, Arrays.asList(startkey), 0, recordcount, 6);
-    } catch (TarantoolException exc) {
+      Conditions conditions = Conditions.greaterOrEquals(1, startkey).withLimit(recordcount).withOffset(0);
+      selectResult = testSpace.select(conditions).join();
+
+    } catch (TarantoolClientException exc) {
       LOGGER.log(Level.SEVERE, "Can't select range elements", exc);
       return Status.ERROR;
-    } catch (NullPointerException exc) {
+    } catch (Exception exc) {
       return Status.ERROR;
     }
-    for (List<String> i : response) {
-      HashMap<String, ByteIterator> temp = tupleConvertFilter(i, fields);
+
+    for (TarantoolTuple p: selectResult) {
+      HashMap<String, ByteIterator> temp = tupleConvertFilter(p, fields);
       if (!temp.isEmpty()) {
         result.add((HashMap<String, ByteIterator>) temp.clone());
       }
@@ -115,9 +187,10 @@ public class TarantoolClient extends DB {
 
   @Override
   public Status delete(String table, String key) {
+
     try {
-      this.connection.delete(this.spaceNo, Collections.singletonList(key));
-    } catch (TarantoolException exc) {
+      this.testSpace.delete(Conditions.equals(KEY_FIELD_NAME, key)).join();
+    } catch (TarantoolClientException exc) {
       LOGGER.log(Level.SEVERE, "Can't delete element", exc);
       return Status.ERROR;
     } catch (NullPointerException e) {
@@ -132,20 +205,26 @@ public class TarantoolClient extends DB {
   }
 
   private Status replace(String key, Map<String, ByteIterator> values, String exceptionDescription) {
-    int j = 0;
-    String[] tuple = new String[1 + 2 * values.size()];
-    tuple[0] = key;
+
+    List<Object> tupleList = new ArrayList<>();
+    tupleList.add(null); // sharding key
+    tupleList.add(key);
     for (Map.Entry<String, ByteIterator> i : values.entrySet()) {
-      tuple[j + 1] = i.getKey();
-      tuple[j + 2] = i.getValue().toString();
-      j += 2;
+      tupleList.add(i.getKey());
+      tupleList.add(i.getValue().toString());
     }
+
     try {
-      this.connection.replace(this.spaceNo, tuple);
-    } catch (TarantoolException exc) {
+      TarantoolTuple newTuple = TUPLEFACTORY.create(tupleList);
+      this.testSpace.replace(newTuple).get();
+    } catch (TarantoolClientException exc) {
+      LOGGER.log(Level.SEVERE, exceptionDescription, exc);
+      return Status.ERROR;
+    } catch (Exception exc) {
       LOGGER.log(Level.SEVERE, exceptionDescription, exc);
       return Status.ERROR;
     }
+
     return Status.OK;
 
   }


### PR DESCRIPTION
Few changes introduced:
1. use of Tarantool cartridge-driver API instead of java connector, 
2. ability to connect to the list of routers by passing argument -p tarantool.hosts=host1:port1,host2:port2, 
3. ability to connect to space by its name by passing argument -p tarantool.spaceName="mySpace",
4. arguments tarantool.host and tarantool.port not used.